### PR TITLE
Add support for running 'pick' on sequences of spectrum images.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog (niondata)
 ====================
 
+0.13.11 (UNRELEASED)
+--------------------
+- Make pick functions work for sequences of spectrum images.
+
 0.13.10 (2020-02-26)
 --------------------
 - Change shift/align functions to use spline-1st-order; add Fourier variants as alternative.

--- a/nion/data/test/Core_test.py
+++ b/nion/data/test/Core_test.py
@@ -247,6 +247,21 @@ class TestCore(unittest.TestCase):
         self.assertEqual(pick.intensity_calibration, c0)
         self.assertEqual(pick.dimensional_calibrations[0], c3)
 
+    def test_pick_grabs_datum_index_from_sequence_of_3d(self):
+        random_data = numpy.random.randn(2, 3, 4, 5)
+        cs = Calibration.Calibration(units="s")
+        c0 = Calibration.Calibration(units="a")
+        c1 = Calibration.Calibration(units="b")
+        c2 = Calibration.Calibration(units="c")
+        c3 = Calibration.Calibration(units="d")
+        data_and_metadata = DataAndMetadata.new_data_and_metadata(random_data, intensity_calibration=c0, dimensional_calibrations=[cs, c1, c2, c3], data_descriptor=DataAndMetadata.DataDescriptor(True, 2, 1))  # last index is signal
+        pick = Core.function_pick(data_and_metadata, (2/3, 1/4))
+        self.assertTrue(numpy.array_equal(random_data[:, 2, 1, :], pick.data))
+        self.assertSequenceEqual(pick.dimensional_shape, (random_data.shape[0], random_data.shape[-1]))
+        self.assertEqual(pick.intensity_calibration, c0)
+        self.assertEqual(pick.dimensional_calibrations[0], cs)
+        self.assertEqual(pick.dimensional_calibrations[1], c3)
+
     def test_pick_grabs_datum_index_from_4d(self):
         random_data = numpy.random.randn(3, 4, 5, 6)
         c0 = Calibration.Calibration(units="a")
@@ -261,6 +276,23 @@ class TestCore(unittest.TestCase):
         self.assertEqual(pick.intensity_calibration, c0)
         self.assertEqual(pick.dimensional_calibrations[0], c3)
         self.assertEqual(pick.dimensional_calibrations[1], c4)
+
+    def test_pick_grabs_datum_index_from_sequence_of_4d(self):
+        random_data = numpy.random.randn(2, 3, 4, 5, 6)
+        cs = Calibration.Calibration(units="s")
+        c0 = Calibration.Calibration(units="a")
+        c1 = Calibration.Calibration(units="b")
+        c2 = Calibration.Calibration(units="c")
+        c3 = Calibration.Calibration(units="d")
+        c4 = Calibration.Calibration(units="e")
+        data_and_metadata = DataAndMetadata.new_data_and_metadata(random_data, intensity_calibration=c0, dimensional_calibrations=[cs, c1, c2, c3, c4], data_descriptor=DataAndMetadata.DataDescriptor(True, 2, 2))
+        pick = Core.function_pick(data_and_metadata, (2/3, 1/4))
+        self.assertTrue(numpy.array_equal(random_data[:, 2, 1, ...], pick.data))
+        self.assertSequenceEqual(pick.dimensional_shape, (random_data.shape[0], random_data.shape[3], random_data.shape[4]))
+        self.assertEqual(pick.intensity_calibration, c0)
+        self.assertEqual(pick.dimensional_calibrations[0], cs)
+        self.assertEqual(pick.dimensional_calibrations[1], c3)
+        self.assertEqual(pick.dimensional_calibrations[2], c4)
 
     def test_sum_region_produces_correct_result(self):
         random_data = numpy.random.randn(3, 4, 5)
@@ -278,6 +310,61 @@ class TestCore(unittest.TestCase):
         self.assertEqual(sum_region.dimensional_shape, (random_data.shape[-1],))
         self.assertEqual(sum_region.intensity_calibration, c0)
         self.assertEqual(sum_region.dimensional_calibrations[0], c3)
+
+    def test_sum_region_produces_correct_result_for_sequence(self):
+        random_data = numpy.random.randn(2, 3, 4, 5)
+        cs = Calibration.Calibration(units="s")
+        c0 = Calibration.Calibration(units="a")
+        c1 = Calibration.Calibration(units="b")
+        c2 = Calibration.Calibration(units="c")
+        c3 = Calibration.Calibration(units="d")
+        data = DataAndMetadata.new_data_and_metadata(random_data, intensity_calibration=c0, dimensional_calibrations=[cs, c1, c2, c3], data_descriptor=DataAndMetadata.DataDescriptor(True, 2, 1))  # last index is signal
+        mask_data = numpy.zeros((3, 4), numpy.int)
+        mask_data[0, 1] = 1
+        mask_data[2, 2] = 1
+        mask = DataAndMetadata.new_data_and_metadata(mask_data)
+        sum_region = Core.function_sum_region(data, mask)
+        self.assertTrue(numpy.array_equal(random_data[:, 0, 1, :] + random_data[:, 2, 2, :], sum_region.data))
+        self.assertEqual(sum_region.dimensional_shape, (random_data.shape[0], random_data.shape[-1]))
+        self.assertEqual(sum_region.intensity_calibration, c0)
+        self.assertEqual(sum_region.dimensional_calibrations[0], cs)
+        self.assertEqual(sum_region.dimensional_calibrations[1], c3)
+
+    def test_average_region_produces_correct_result(self):
+        random_data = numpy.random.randn(3, 4, 5)
+        c0 = Calibration.Calibration(units="a")
+        c1 = Calibration.Calibration(units="b")
+        c2 = Calibration.Calibration(units="c")
+        c3 = Calibration.Calibration(units="d")
+        data = DataAndMetadata.new_data_and_metadata(random_data, intensity_calibration=c0, dimensional_calibrations=[c1, c2, c3])  # last index is signal
+        mask_data = numpy.zeros((3, 4), numpy.int)
+        mask_data[0, 1] = 1
+        mask_data[2, 2] = 1
+        mask = DataAndMetadata.new_data_and_metadata(mask_data)
+        average_region = Core.function_average_region(data, mask)
+        self.assertTrue(numpy.array_equal((random_data[0, 1, :] + random_data[2, 2, :])/2, average_region.data))
+        self.assertEqual(average_region.dimensional_shape, (random_data.shape[-1],))
+        self.assertEqual(average_region.intensity_calibration, c0)
+        self.assertEqual(average_region.dimensional_calibrations[0], c3)
+
+    def test_average_region_produces_correct_result_for_sequence(self):
+        random_data = numpy.random.randn(2, 3, 4, 5)
+        cs = Calibration.Calibration(units="s")
+        c0 = Calibration.Calibration(units="a")
+        c1 = Calibration.Calibration(units="b")
+        c2 = Calibration.Calibration(units="c")
+        c3 = Calibration.Calibration(units="d")
+        data = DataAndMetadata.new_data_and_metadata(random_data, intensity_calibration=c0, dimensional_calibrations=[cs, c1, c2, c3], data_descriptor=DataAndMetadata.DataDescriptor(True, 2, 1))  # last index is signal
+        mask_data = numpy.zeros((3, 4), numpy.int)
+        mask_data[0, 1] = 1
+        mask_data[2, 2] = 1
+        mask = DataAndMetadata.new_data_and_metadata(mask_data)
+        average_region = Core.function_average_region(data, mask)
+        self.assertTrue(numpy.array_equal((random_data[:, 0, 1, :] + random_data[:, 2, 2, :])/2, average_region.data))
+        self.assertEqual(average_region.dimensional_shape, (random_data.shape[0], random_data.shape[-1]))
+        self.assertEqual(average_region.intensity_calibration, c0)
+        self.assertEqual(average_region.dimensional_calibrations[0], cs)
+        self.assertEqual(average_region.dimensional_calibrations[1], c3)
 
     def test_slice_sum_works_on_2d_data(self):
         random_data = numpy.random.randn(4, 10)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=open("README.rst").read(),
     url="https://github.com/nion-software/niondata",
     packages=["nion.data", "nion.data.test"],
-    install_requires=['scipy', 'numpy>=1.16', 'nionutils'],
+    install_requires=['scipy', 'numpy>=1.17', 'nionutils'],
     license='Apache 2.0',
     classifiers=[
         "Development Status :: 2 - Pre-Alpha"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,6 @@
 
 -e git://github.com/nion-software/nionutils.git#egg=nionutils
 
-numpy>=1.16
+numpy>=1.17
 scipy
 h5py


### PR DESCRIPTION
This is in preparation for and updated `MultiAcquire` that will allow users to acquire sequences of spectrum images.