### PR TITLE
Added functions for splitting and joining sequences.

### DIFF
--- a/nion/data/Core.py
+++ b/nion/data/Core.py
@@ -1137,6 +1137,7 @@ def function_concatenate(data_and_metadata_list: typing.Sequence[DataAndMetadata
     form of the numpy function of the same name.
 
     Keeps intensity calibration of first source item.
+    Keeps data descriptor of first source item.
 
     Keeps dimensional calibration in axis dimension.
     """
@@ -1170,8 +1171,9 @@ def function_concatenate(data_and_metadata_list: typing.Sequence[DataAndMetadata
                 dimensional_calibrations[index] = Calibration.Calibration()
 
     intensity_calibration = data_and_metadata_list[0].intensity_calibration
+    data_descriptor = data_and_metadata_list[0].data_descriptor
 
-    return DataAndMetadata.new_data_and_metadata(calculate_data(), intensity_calibration=intensity_calibration, dimensional_calibrations=dimensional_calibrations)
+    return DataAndMetadata.new_data_and_metadata(calculate_data(), intensity_calibration=intensity_calibration, dimensional_calibrations=dimensional_calibrations, data_descriptor=data_descriptor)
 
 
 def function_hstack(data_and_metadata_list: typing.Sequence[DataAndMetadata.DataAndMetadata]) -> DataAndMetadata.DataAndMetadata:

--- a/nion/data/test/Core_test.py
+++ b/nion/data/test/Core_test.py
@@ -916,6 +916,25 @@ class TestCore(unittest.TestCase):
         self.assertTrue(numpy.allclose(max_pos, (50, 17), atol=0.1))
         self.assertAlmostEqual(ccoeff, 1.0, places=1)
 
+    def test_sequence_join(self):
+        xdata_list = [DataAndMetadata.new_data_and_metadata(numpy.ones((16, 32)), data_descriptor=DataAndMetadata.DataDescriptor(False, 1, 1))]
+        xdata_list.append(DataAndMetadata.new_data_and_metadata(numpy.ones((2, 16, 32)), data_descriptor=DataAndMetadata.DataDescriptor(True, 1, 1)))
+        xdata_list.append(DataAndMetadata.new_data_and_metadata(numpy.ones((1, 16, 32)), data_descriptor=DataAndMetadata.DataDescriptor(True, 1, 1)))
+        sequence_xdata = Core.function_sequence_join(xdata_list)
+        self.assertTrue(sequence_xdata.is_sequence)
+        self.assertTrue(sequence_xdata.is_collection)
+        self.assertSequenceEqual(sequence_xdata.data_shape, (4, 16, 32))
+
+    def test_sequence_split(self):
+        sequence_xdata = DataAndMetadata.new_data_and_metadata(numpy.ones((3, 16, 32)), data_descriptor=DataAndMetadata.DataDescriptor(True, 1, 1))
+        xdata_list = Core.function_sequence_split(sequence_xdata)
+        self.assertEqual(len(xdata_list), 3)
+        for xdata in xdata_list:
+            self.assertSequenceEqual(xdata.data_shape, (16, 32))
+            self.assertTrue(xdata.is_collection)
+            self.assertFalse(xdata.is_sequence)
+
+
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)
     unittest.main()

--- a/nion/data/test/Core_test.py
+++ b/nion/data/test/Core_test.py
@@ -112,6 +112,34 @@ class TestCore(unittest.TestCase):
         self.assertEqual(tuple(c0.data.shape), tuple(c0.data_shape))
         self.assertTrue(numpy.array_equal(c0.data, numpy.concatenate([src_data1, src_data2], 0)))
 
+    def test_concatenate_propagates_data_descriptor(self):
+        data1 = numpy.ones((16, 32))
+        data2 = numpy.ones((8, 32))
+
+        data_descriptor = DataAndMetadata.DataDescriptor(True, 0, 1)
+        xdata1 = DataAndMetadata.new_data_and_metadata(data1, data_descriptor=data_descriptor)
+        xdata2 = DataAndMetadata.new_data_and_metadata(data2, data_descriptor=data_descriptor)
+        concatenated = Core.function_concatenate([xdata1, xdata2])
+        self.assertTrue(concatenated.is_sequence)
+        self.assertFalse(concatenated.is_collection)
+        self.assertEqual(concatenated.datum_dimension_count, 1)
+
+        data_descriptor = DataAndMetadata.DataDescriptor(False, 1, 1)
+        xdata1 = DataAndMetadata.new_data_and_metadata(data1, data_descriptor=data_descriptor)
+        xdata2 = DataAndMetadata.new_data_and_metadata(data2, data_descriptor=data_descriptor)
+        concatenated = Core.function_concatenate([xdata1, xdata2])
+        self.assertFalse(concatenated.is_sequence)
+        self.assertTrue(concatenated.is_collection)
+        self.assertEqual(concatenated.datum_dimension_count, 1)
+
+        data_descriptor = DataAndMetadata.DataDescriptor(False, 0, 2)
+        xdata1 = DataAndMetadata.new_data_and_metadata(data1, data_descriptor=data_descriptor)
+        xdata2 = DataAndMetadata.new_data_and_metadata(data2, data_descriptor=data_descriptor)
+        concatenated = Core.function_concatenate([xdata1, xdata2])
+        self.assertFalse(concatenated.is_sequence)
+        self.assertFalse(concatenated.is_collection)
+        self.assertEqual(concatenated.datum_dimension_count, 2)
+
     def test_concatenate_calibrations(self):
         src_data1 = numpy.zeros((4, 8, 16))
         src_data2 = numpy.zeros((4, 8, 16))

--- a/nion/data/xdata_1_0.py
+++ b/nion/data/xdata_1_0.py
@@ -294,8 +294,14 @@ def sequence_insert(src1: DataAndMetadata.DataAndMetadata, src2: DataAndMetadata
 def sequence_concatenate(src1: DataAndMetadata.DataAndMetadata, src2: DataAndMetadata.DataAndMetadata) -> DataAndMetadata.DataAndMetadata:
     return Core.function_sequence_concatenate(src1, src2)
 
+def sequence_join(data_and_metadata_list: typing.Sequence[DataAndMetadata.DataAndMetadata]) -> DataAndMetadata.DataAndMetadata:
+    return Core.function_sequence_join(data_and_metadata_list)
+
 def sequence_extract(src: DataAndMetadata.DataAndMetadata, position: int) -> DataAndMetadata.DataAndMetadata:
     return Core.function_sequence_extract(src, position)
+
+def sequence_split(src: DataAndMetadata.DataAndMetadata) -> typing.List[DataAndMetadata.DataAndMetadata]:
+    return Core.function_sequence_split(src)
 
 # utility functions
 


### PR DESCRIPTION
This is the low-level stuff needed for nion-software/nionswift#69.

For now the UI is in nion-software/experimental#6 until the built-in processing routines in nion-software/nionswift support lists of input/output items with an undefined number of items in them.