### PR TITLE
Add functions for affine transformation. Add order argument to function_warp and make order=1 the default.

### DIFF
--- a/nion/data/test/Core_test.py
+++ b/nion/data/test/Core_test.py
@@ -970,6 +970,27 @@ class TestCore(unittest.TestCase):
             self.assertTrue(xdata.is_collection)
             self.assertFalse(xdata.is_sequence)
 
+    def test_affine_transform(self):
+        data_shapes = [(5, 5)]#, (6, 6)]
+        for data_shape in data_shapes:
+            with self.subTest(data_shape=data_shape):
+                original_data = numpy.zeros(data_shape)
+                original_data[1:-1, 2:-2] = 1
+                transformation_matrix = numpy.array(((numpy.cos(numpy.pi/2), -numpy.sin(numpy.pi/2), 0),
+                                                     (numpy.sin(numpy.pi/2),  numpy.cos(numpy.pi/2), 0),
+                                                     (0,                      0,                     1)))
+                transformed = Core.function_affine_transform(original_data, transformation_matrix, order=1)
+                self.assertTrue(numpy.allclose(numpy.rot90(original_data), transformed.data))
+
+    def test_affine_transform_does_identity_correctly(self):
+        data_shapes = [(4, 4), (5, 5)]
+        for data_shape in data_shapes:
+            with self.subTest(data_shape=data_shape):
+                original_data = numpy.random.rand(*data_shape)
+                transformation_matrix = numpy.array(((1, 0), (0, 1)))
+                transformed = Core.function_affine_transform(original_data, transformation_matrix, order=1)
+                self.assertTrue(numpy.allclose(original_data, transformed.data))
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)

--- a/nion/data/xdata_1_0.py
+++ b/nion/data/xdata_1_0.py
@@ -90,8 +90,11 @@ def rebin_image(data_and_metadata: DataAndMetadata.DataAndMetadata, shape: DataA
 def resample_image(data_and_metadata: DataAndMetadata.DataAndMetadata, shape: DataAndMetadata.ShapeType) -> DataAndMetadata.DataAndMetadata:
     return Core.function_resample_2d(data_and_metadata, shape)
 
-def warp(data_and_metadata: DataAndMetadata.DataAndMetadata, coordinates: typing.Sequence[DataAndMetadata.DataAndMetadata]) -> DataAndMetadata.DataAndMetadata:
+def warp(data_and_metadata: DataAndMetadata.DataAndMetadata, coordinates: typing.Sequence[DataAndMetadata.DataAndMetadata], order: int=1) -> DataAndMetadata.DataAndMetadata:
     return Core.function_warp(data_and_metadata, coordinates)
+
+def affine_transform(data_and_metadata: DataAndMetadata.DataAndMetadata, transformation_matrix: numpy.ndarray, order: int=1) -> DataAndMetadata.DataAndMetadata:
+    return Core.function_affine_transform(data_and_metadata, transformation_matrix, order=order)
 
 # functions generating ndarrays
 # TODO: move these bodies to Core once Core usage has been migrated


### PR DESCRIPTION
Interpolation order 3 is usually not useful for our data. We want to keep the total intensity in an image the same when we interpolate, which only linear interpolation can do. Also noisy data will not produce good results with interpolation other than linear. 