### PR TITLE
Rebin 1d

### DIFF
--- a/nion/data/Core.py
+++ b/nion/data/Core.py
@@ -1683,7 +1683,7 @@ def function_rebin_2d(data_and_metadata_in: _DataAndMetadataLike, shape: DataAnd
     return DataAndMetadata.new_data_and_metadata(calculate_data(), intensity_calibration=data_and_metadata.intensity_calibration, dimensional_calibrations=rebinned_dimensional_calibrations)
 
 
-def _binned_data_shape_and_crop_slices(shape: DataAndMetadata.ShapeType, binning: typing.Tuple[int, ...]):
+def _binned_data_shape_and_crop_slices(shape: DataAndMetadata.ShapeType, binning: typing.Tuple[int, ...]) -> typing.Tuple[typing.Tuple[int, ...], typing.Optional[typing.Tuple[slice, ...]]]:
     if binning == 1:
         return shape, None
     new_shape = [shape[i] // binning[i] for i in range(len(shape))]
@@ -1692,7 +1692,7 @@ def _binned_data_shape_and_crop_slices(shape: DataAndMetadata.ShapeType, binning
     return tuple(new_shape), tuple([slice(half_residue[i] + residue[i] % 2, -half_residue[i] if half_residue[i] > 0 else None) for i in range(len(residue))])
 
 
-def _rebin(arr, new_shape, dtype=None, out=None):
+def _rebin(arr: _ImageDataType, new_shape: DataAndMetadata.ShapeType, dtype: typing.Optional[numpy.typing.DTypeLike] = None, out: typing.Optional[_ImageDataType] = None) -> typing.Optional[_ImageDataType]:
     if new_shape == arr.shape:
         if out is not None:
             out[:] = arr

--- a/nion/data/Core.py
+++ b/nion/data/Core.py
@@ -1716,7 +1716,7 @@ def _rebin(arr: _ImageDataType, new_shape: DataAndMetadata.ShapeType, dtype: typ
     return None
 
 
-def function_rebin(data_and_metadata_in: _DataAndMetadataLike, binning: typing.Tuple[int, ...]) -> DataAndMetadata.DataAndMetadata:
+def function_rebin_factor(data_and_metadata_in: _DataAndMetadataLike, binning: typing.Tuple[int, ...]) -> DataAndMetadata.DataAndMetadata:
     data_and_metadata = DataAndMetadata.promote_ndarray(data_and_metadata_in)
 
     if not Image.is_data_valid(data_and_metadata.data):

--- a/nion/data/test/MultiDimensionalProcessing_test.py
+++ b/nion/data/test/MultiDimensionalProcessing_test.py
@@ -13,6 +13,13 @@ _ = gettext.gettext
 
 class TestMultiDimensionalProcessing(unittest.TestCase):
 
+    def setUp(self) -> None:
+        self.__random_state = numpy.random.get_state()
+        numpy.random.seed(42)
+
+    def tearDown(self) -> None:
+        numpy.random.set_state(self.__random_state)
+
     def test_function_apply_multi_dimensional_shifts_4d(self) -> None:
         with self.subTest("Test for a sequence of SIs, shift collection dimensions along sequence axis"):
             shape = (5, 2, 3, 4)

--- a/nion/data/xdata_1_0.py
+++ b/nion/data/xdata_1_0.py
@@ -91,8 +91,8 @@ def sum_region(data_and_metadata: _DataAndMetadataLike, mask_data_and_metadata: 
 def average_region(data_and_metadata: _DataAndMetadataLike, mask_data_and_metadata: _DataAndMetadataLike) -> DataAndMetadata.DataAndMetadata:
     return Core.function_average_region(data_and_metadata, mask_data_and_metadata)
 
-def rebin_image(data_and_metadata: _DataAndMetadataLike, shape: DataAndMetadata.ShapeType) -> DataAndMetadata.DataAndMetadata:
-    return Core.function_rebin_2d(data_and_metadata, shape)
+def rebin_image(data_and_metadata: _DataAndMetadataLike, binning: DataAndMetadata.ShapeType) -> DataAndMetadata.DataAndMetadata:
+    return Core.function_rebin(data_and_metadata, binning)
 
 def resample_image(data_and_metadata: _DataAndMetadataLike, shape: DataAndMetadata.ShapeType) -> DataAndMetadata.DataAndMetadata:
     return Core.function_resample_2d(data_and_metadata, shape)

--- a/nion/data/xdata_1_0.py
+++ b/nion/data/xdata_1_0.py
@@ -91,8 +91,11 @@ def sum_region(data_and_metadata: _DataAndMetadataLike, mask_data_and_metadata: 
 def average_region(data_and_metadata: _DataAndMetadataLike, mask_data_and_metadata: _DataAndMetadataLike) -> DataAndMetadata.DataAndMetadata:
     return Core.function_average_region(data_and_metadata, mask_data_and_metadata)
 
-def rebin_image(data_and_metadata: _DataAndMetadataLike, binning: DataAndMetadata.ShapeType) -> DataAndMetadata.DataAndMetadata:
-    return Core.function_rebin(data_and_metadata, binning)
+def rebin_image(data_and_metadata: _DataAndMetadataLike, shape: DataAndMetadata.ShapeType) -> DataAndMetadata.DataAndMetadata:
+    return Core.function_rebin_2d(data_and_metadata, shape)
+
+def rebin_factor(data_and_metadata: _DataAndMetadataLike, binning: typing.Tuple[int, ...]) -> DataAndMetadata.DataAndMetadata:
+    return Core.function_rebin_factor(data_and_metadata, binning)
 
 def resample_image(data_and_metadata: _DataAndMetadataLike, shape: DataAndMetadata.ShapeType) -> DataAndMetadata.DataAndMetadata:
     return Core.function_resample_2d(data_and_metadata, shape)


### PR DESCRIPTION
This adds an improved rebin function that can work on 1d and 2d data. It also allows binning by arbitrary integers, not only factors of the input data shape. This is done by cropping the input data so that the requested binning value becomes a factor of its shape.
This also handles binning down 2d data to 1d as a special case.