### PR TITLE
Fix #1471. Fix FFT calibration for odd dimensions. Test.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog (niondata)
 ====================
 
+UNRELEASED
+----------
+- Fix FFT calibration for odd dimensions.
+
 15.9.0 (2025-06-25)
 -------------------
 - Add rectangle mask generation functions.

--- a/nion/data/Core.py
+++ b/nion/data/Core.py
@@ -181,8 +181,10 @@ def function_fft(data_and_metadata_in: _DataAndMetadataLike) -> DataAndMetadata.
 
     assert len(src_dimensional_calibrations) == len(Image.dimensional_shape_from_shape_and_dtype(data_shape, data_dtype) or ())
 
+    # zero_frequency_position = numpy.array((numpy.array(data_shape) // 2)) + 0.5
+
     dimensional_calibrations = [
-        Calibration.Calibration((-0.5 - 0.5 * data_shape_n) / (dimensional_calibration.scale * data_shape_n),
+        Calibration.Calibration((-0.5 - data_shape_n // 2) / (dimensional_calibration.scale * data_shape_n),
                                 1.0 / (dimensional_calibration.scale * data_shape_n),
                                 "1/" + dimensional_calibration.units) for dimensional_calibration, data_shape_n in
         zip(src_dimensional_calibrations, data_shape)]

--- a/nion/data/test/Core_test.py
+++ b/nion/data/test/Core_test.py
@@ -1319,6 +1319,23 @@ class TestCore(unittest.TestCase):
         mask = mask_xdata.data
         self.assertTrue(numpy.all(mask == 0))
 
+    def test_fft_zero_component_calibration(self) -> None:
+        dimensional_calibrations = (Calibration.Calibration(0, 1, "S"), Calibration.Calibration(0, 1, "S"))
+        xdata = DataAndMetadata.new_data_and_metadata(data=numpy.ones((16, 8)), dimensional_calibrations=dimensional_calibrations)
+        result = Core.function_fft(xdata)
+        self.assertAlmostEqual(0.0, result.dimensional_calibrations[0].convert_to_calibrated_value(8.5))
+        self.assertAlmostEqual(0.0, result.dimensional_calibrations[1].convert_to_calibrated_value(4.5))
+        xdata2 = DataAndMetadata.new_data_and_metadata(data=numpy.ones((15, 9)), dimensional_calibrations=dimensional_calibrations)
+        result2 = Core.function_fft(xdata2)
+        self.assertAlmostEqual(0.0, result2.dimensional_calibrations[0].convert_to_calibrated_value(7.5))
+        self.assertAlmostEqual(0.0, result2.dimensional_calibrations[1].convert_to_calibrated_value(4.5))
+        xdata3 = DataAndMetadata.new_data_and_metadata(data=numpy.ones((16,)), dimensional_calibrations=dimensional_calibrations[0:1])
+        result3 = Core.function_fft(xdata3)
+        self.assertAlmostEqual(0.0, result3.dimensional_calibrations[0].convert_to_calibrated_value(8.5))
+        xdata4 = DataAndMetadata.new_data_and_metadata(data=numpy.ones((15,)), dimensional_calibrations=dimensional_calibrations[0:1])
+        result4 = Core.function_fft(xdata4)
+        self.assertAlmostEqual(0.0, result4.dimensional_calibrations[0].convert_to_calibrated_value(7.5))
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
Fixes #70.

Please review this carefully. The tests describe the calibration assumptions for the zero frequency position: 0.5 into the "center" pixel.

NOTE: this is easiest to test if you apply https://github.com/nion-software/nionswift/pull/1597 (fix drawing of spot graphics) if it hasn't already been merged.